### PR TITLE
Add option to allow creation of multiple .onion addresses

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -14,6 +14,7 @@ void usage(void) {
          "  -m        : Monitor mode (incompatible with -f)\n"
 	 "  -o        : Optimize RSA key size to improve SHA-1 hashing speed\n"
          "  -p        : Print 'pattern' help and exit\n"
+         "  -c        : Continue finding matches after a match is found\n"
          "  -f <file> : Write output to <file>\n"
          "  -t count  : Forces exactly count threads to be spawned\n"
          "  -x secs   : Sets a limit on the maximum execution time. Has no effect without -m\n"

--- a/src/globals.h
+++ b/src/globals.h
@@ -12,6 +12,7 @@
 // TODO: also put settings in a struct
 uint64_t loop, elim;
 uint8_t found, monitor, maxexectime;
+uint8_t continuous;
 pthread_t lucky_thread;
 regex_t *regex;
 

--- a/src/shallot.c
+++ b/src/shallot.c
@@ -154,6 +154,10 @@ int main(int argc, char *argv[]) { // onions are fun, here we go
           optimum = 1;
           break;
         }
+        case 'c': { // continuous brute-forcing
+          continuous = 1;
+          break;
+        }
         case 'f': { // file <file>
           if((argv[x][y + 1] != '\0') || (x + 1 > argc)) {
             fprintf(stderr, "Error: -f format is '-f <file>'\n");

--- a/src/thread.c
+++ b/src/thread.c
@@ -73,10 +73,6 @@ void *worker(void *params) { // life cycle of a cracking pthread
 
       if(!regexec(regex, onion, 0, 0, 0)) { // check for a match
 
-        // let our main thread know on which thread to wait
-        lucky_thread = pthread_self();
-        found = 1; // kill off our other threads, asynchronously
-
         if(monitor)
           printf("\n"); // keep our printing pretty!
 
@@ -89,9 +85,19 @@ void *worker(void *params) { // life cycle of a cracking pthread
         print_onion(onion); // print our domain
         print_prkey(rsa);   // and more importantly the key
 
-        RSA_free(rsa); // free up what's left
+        if (!continuous) { // no -c option — terminate
 
-        return 0;
+          // let our main thread know on which thread to wait
+          lucky_thread = pthread_self();
+          found = 1; // kill off our other threads, asynchronously
+
+          RSA_free(rsa); // free up what's left
+
+          return 0;
+
+        } else { // -c option specified, keep going
+          printf("\n\n"); // put some space between each result
+        }
       }
 
       e += 2; // do *** NOT *** forget this!

--- a/src/thread.c
+++ b/src/thread.c
@@ -82,17 +82,18 @@ void *worker(void *params) { // life cycle of a cracking pthread
         if(!sane_key(rsa))        // check our key
           error(X_YOURE_UNLUCKY); // bad key :(
 
+        if (!continuous) { // no -c option — terminate
+          // let our main thread know on which thread to wait
+          lucky_thread = pthread_self();
+          found = 1; // kill off our other threads, asynchronously
+        }
+
         print_onion(onion); // print our domain
         print_prkey(rsa);   // and more importantly the key
 
         if (!continuous) { // no -c option — terminate
 
-          // let our main thread know on which thread to wait
-          lucky_thread = pthread_self();
-          found = 1; // kill off our other threads, asynchronously
-
           RSA_free(rsa); // free up what's left
-
           return 0;
 
         } else { // -c option specified, keep going


### PR DESCRIPTION
When creating an .onion address, sometimes I want to have multiple ones with a particular prefix created so I can pick the one that looks the best or is the most memorable. By passing the `-c` option, Shallot will generate .onion addresses until it is terminated.
```
$./shallot -c ^tails
```
will generate key after key so I can pick from multiple `tails***********.onion` addresses for the one that I like best.

I think there’s still some memory issues with this patch, but I’m opening this PR anyway for review by others.