### PR TITLE
Updated API calls to OpenSSL 1.1.0 (RSA and BIGNUM members)

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -32,6 +32,7 @@ void *worker(void *params) { // life cycle of a cracking pthread
   char onion[BASE32_ONIONLEN];
   SHA_CTX hash, copy;
   RSA *rsa;
+  BIGNUM *rsae;
 
   while(!found) {
     // keys are only generated every so often
@@ -80,7 +81,8 @@ void *worker(void *params) { // life cycle of a cracking pthread
         if(monitor)
           printf("\n"); // keep our printing pretty!
 
-        if(!BN_bin2bn(e_ptr, e_bytes, rsa->e)) // store our e in the actual key
+	RSA_get0_key(rsa, NULL, &rsae, NULL);
+        if(!BN_bin2bn(e_ptr, e_bytes, rsae))   // store our e in the actual key
           error(X_BIGNUM_FAILED);              // and make sure it got there
 
         if(!sane_key(rsa))        // check our key


### PR DESCRIPTION
I have OpenSSL 1.1.0 installed an ran into trouble while compiling. Eventually i found out, the OpenSSL devs changed their API (https://wiki.openssl.org/index.php/1.1_API_Changes (tldr: all structs are now opaque and getters are needed)). Hopefully I have covered all issues going along with the API change.