### PR TITLE
Update API for OpenSSL 1.1.1d, and speed up on patterns like "^foo"

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -2,6 +2,7 @@
 #define GLOBALS_H
 
 #include "config.h"
+#include "defines.h"
 
 #include <regex.h>
 #include <stdint.h>
@@ -14,5 +15,7 @@ uint64_t loop, elim;
 uint8_t found, monitor, maxexectime;
 pthread_t lucky_thread;
 regex_t *regex;
+char prefix[BASE32_ONIONLEN];
+size_t prefix_size;
 
 #endif

--- a/src/shallot.c
+++ b/src/shallot.c
@@ -59,6 +59,30 @@ void terminate(int signum) { // Ctrl-C/kill handler
   error(X_SGNL_INT_TERM);
 }
 
+int is_base32_abc(char c) {
+  const char* it;
+  for(it = BASE32_ALPHABET; *it; ++it) {
+    if (c == *it)
+      return 1;
+  }
+  return 0;
+}
+
+int is_prefix(const char* pattern) {
+  if(strlen(pattern) == 0)
+    return 0;
+  if(pattern[0] != '^')
+    return 0;
+  const char* actual_pattern = pattern + 1; // cut ^
+  const char* it;
+  for(it = actual_pattern; *it; ++it) {
+    if(!is_base32_abc(*it)) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
 int main(int argc, char *argv[]) { // onions are fun, here we go
   signal(SIGTERM, terminate); // always let people kill
 
@@ -223,10 +247,18 @@ int main(int argc, char *argv[]) { // onions are fun, here we go
   if(*pattern == '-')
     error(X_REGEX_INVALID);
 
-  regex = malloc(REGEX_COMP_LMAX);
-
-  if(regcomp(regex, pattern, REG_EXTENDED | REG_NOSUB))
-    error(X_REGEX_COMPILE);
+  if(is_prefix(pattern)) {
+    const char* actual_pattern = pattern + 1; // cut ^
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+    strncpy(prefix, actual_pattern, BASE32_ONIONLEN);
+#pragma GCC diagnostic pop
+    prefix_size = strlen(actual_pattern);
+  } else {
+    regex = malloc(REGEX_COMP_LMAX);
+    if (regcomp(regex, pattern, REG_EXTENDED | REG_NOSUB))
+      error(X_REGEX_COMPILE);
+  }
 
   if(file) {
     umask(077); // remove permissions to be safe
@@ -288,6 +320,8 @@ int main(int argc, char *argv[]) { // onions are fun, here we go
     pthread_join(lucky_thread, NULL); // wait for the lucky thread to exit
   }
 
-  regfree(regex);
+  if(regex)
+    regfree(regex);
+
   return 0;
 }


### PR DESCRIPTION
This merges the changes suggested by @jroeger23 [under 37](https://github.com/katmagic/Shallot/pull/37) and @starius [under 25](https://github.com/katmagic/Shallot/pull/25).

I have OpenSSL 1.1.1d installed an ran into trouble while compiling it on 
OpenSSL devs changed their API (https://wiki.openssl.org/index.php/1.1_API_Changes

This is my setup, on which it has been tested:
```
Linux 5.4.51+ #1333 Mon Aug 10 16:38:02 BST 2020 armv6l GNU/Linux
gcc 8.3.0
OpenSSL 1.1.1d  10 Sep 2019
```